### PR TITLE
Increased Python version to allow 3.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Matthias Schlögl <m.schloegl@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.6, <3.9"
+python = ">=3.6, <3.12"
 apis-core = ">=0.16.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Updates Python version to allow 3.11.2. Requirement for updating Python and Django versions. See:

https://github.com/acdh-oeaw/apis-core-rdf/pull/41
https://github.com/acdh-oeaw/apis-rdf-devops/pull/42
https://github.com/acdh-oeaw/apis_highlighter/pull/4