### PR TITLE
feat: add convenience views to bibsonomy

### DIFF
--- a/apis_bibsonomy/models.py
+++ b/apis_bibsonomy/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 
+import json
 
 class Reference(models.Model):
     """Model that holds the reference to a bibsonomy entry"""
@@ -14,3 +16,16 @@ class Reference(models.Model):
     last_update = models.DateTimeField(auto_now=True)
     folio = models.CharField(max_length=255, help_text="String to add the folio.", blank=True, null=True)
     notes = models.CharField(max_length=255, help_text="Use to additionally define the location of the information", blank=True, null=True)
+
+    def __str__(self):
+        title = self.bibtexjson.get('title')
+        desc = [title, self.pages_start, self.pages_end, self.folio, self.notes]
+        desc = ", ".join(map(str, filter(None, desc)))
+        return desc
+
+    @property
+    def bibtexjson(self):
+        return json.loads(self.bibtex or "{}")
+
+    def get_absolute_url(self):
+        return reverse("apis_bibsonomy:referencedetail", kwargs={"pk": self.pk})

--- a/apis_bibsonomy/templates/apis_bibsonomy/reference_confirm_delete.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/reference_confirm_delete.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Confirm delete</h3>
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <form action="" method="post">
+                    {% csrf_token %}
+                    <h4>
+                        Are you sure you want to delete: <strong>{{ object }}</strong> ?
+                    </h4>
+                    <input  class="btn btn-danger" type="submit" value="Yes, I want to delete" />
+                </form>
+            </div>
+            <div class="modal-footer">
+                <input  class="btn" type="submit" value="No, bring me back" onclick="goBack()" />
+            </div>
+        </div>
+    </div>
+    <script>
+        function goBack() {
+            window.history.back();
+        }
+    </script>
+{% endblock content %}

--- a/apis_bibsonomy/templates/apis_bibsonomy/reference_detail.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/reference_detail.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="container">
+<div class="px-4 py-5 my-5 text-center">
+<h1>{{ reference }}</h1>
+</div>
+<details>
+	<summary>bibtex</summary>
+	<p>{{ reference.bibtexjson }}</p>
+</details>
+
+<hr/>
+
+Also referenced by:
+<ul>
+{% for ref, obj in referenced_objects %}
+<li>
+{% if obj.get_absolute_url %}<a href="{{ obj.get_absolute_url }}">{{ obj }}</a>{% else %}{{ obj }}{% endif %}
+(<a href="{{ ref.get_absolute_url }}">{{ ref.id }}</a>)
+<a href="{% url "apis_bibsonomy:referencedelete" ref.id %}?redirect={% url "apis_bibsonomy:referencedetail" reference.id %}">Delete</a>
+</li>
+{% endfor %}
+</ul>
+
+{% endblock content %}

--- a/apis_bibsonomy/templates/apis_bibsonomy/reference_list.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/reference_list.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+<div class="px-4 py-5 my-5 text-center">
+<h1>References:</h1>
+</div>
+<ul>
+{% for reference in object_list %}
+<li>
+	<a href="{{ reference.get_absolute_url }}">{{ reference }} ({{ reference.id }})</a>
+</li>
+{% empty %}
+<li>No references yet.</li>
+{% endfor %}
+</ul>
+</div>
+{% endblock content %}

--- a/apis_bibsonomy/templates/base.html
+++ b/apis_bibsonomy/templates/base.html
@@ -1,0 +1,12 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Bibsonomy (base template)</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="{% static 'apis_bibsonomy/css/apis_bibsonomy.css' %}"/>
+    </head>
+    <body>
+    {% block content %}{% endblock content %}
+    </body>
+</html>

--- a/apis_bibsonomy/urls.py
+++ b/apis_bibsonomy/urls.py
@@ -1,11 +1,14 @@
+from rest_framework.routers import DefaultRouter
 from django.urls import path
-from . import api_views
+from . import api_views, views
 from . import autocompletes
 
 app_name = 'apis_bibsonomy'
 
 urlpatterns = [
     path('save_get/', api_views.SaveBibsonomyEntry.as_view(), name='savegetbibsonomyentry'),
-    path('autocomplete/', autocompletes.BibsonomyAutocomplete.as_view(), name='bibsonomyautocomplete')
+    path('autocomplete/', autocompletes.BibsonomyAutocomplete.as_view(), name='bibsonomyautocomplete'),
+    path('references/', views.ReferenceListView.as_view(), name='referencelist'),
+    path('references/<int:pk>', views.ReferenceDetailView.as_view(), name='referencedetail'),
+    path('references/<int:pk>/delete', views.ReferenceDeleteView.as_view(), name='referencedelete'),
 ]
-

--- a/apis_bibsonomy/views.py
+++ b/apis_bibsonomy/views.py
@@ -1,0 +1,49 @@
+from django.views.generic.list import ListView
+from django.views.generic.detail import DetailView
+from django.views.generic.edit import DeleteView
+from django.urls import reverse_lazy
+from django.conf import settings
+from django.db.models import Q
+
+from .models import Reference
+
+
+class ReferenceDetailView(DetailView):
+    model = Reference
+
+    def get_similar_objects(self):
+        # we collect a list of other references instances, that point to the
+        # same reference, and add that to the context
+        obj = self.get_object()
+        similarity_fields = getattr(
+            settings,
+            "REFERENCE_SIMILARITY",
+            ["bibs_url"],
+        )
+        similarity = Q()
+        for field in similarity_fields:
+            similarity &= Q(**{field: getattr(obj, field)})
+        return Reference.objects.filter(similarity)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        similar_references = self.get_similar_objects()
+        context["referenced_objects"] = [
+            (ref, ref.content_type.get_object_for_this_type(id=ref.object_id))
+            for ref in similar_references
+        ]
+        return context
+
+
+class ReferenceDeleteView(DeleteView):
+    model = Reference
+
+    def get_success_url(self):
+        red = self.request.GET.get(
+            "redirect", reverse_lazy("apis_bibsonomy:referencelist")
+        )
+        return red
+
+
+class ReferenceListView(ListView):
+    model = Reference


### PR DESCRIPTION
This commit adds a couple of convenience views to the bibsonomy module -
namely views to list, view and delete References.

It also adds a couple of useful methods to the Reference model - the
string representation of the Reference is now concatenated from title
pages, folio and notes.
A bibtexjson property returns the bibtex string as dict, so we can have
easier access to the bibtex fields. This makes it also possible to
access those fields in templates.

The commit also add templates for the various views and a `base.html`
fallback template.