### PR TITLE
refactor: move logic from view to model

### DIFF
--- a/apis_bibsonomy/templates/apis_bibsonomy/reference_detail.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/reference_detail.html
@@ -5,6 +5,7 @@
 <div class="container">
 <div class="px-4 py-5 my-5 text-center">
 <h1>{{ reference }}</h1>
+on {{ reference.referenced_object }}
 </div>
 <details>
 	<summary>bibtex</summary>
@@ -15,11 +16,13 @@
 
 Also referenced by:
 <ul>
-{% for ref, obj in referenced_objects %}
+{% for ref in similar_references %}
 <li>
+{% with similar_references.referenced_object as obj %}
 {% if obj.get_absolute_url %}<a href="{{ obj.get_absolute_url }}">{{ obj }}</a>{% else %}{{ obj }}{% endif %}
 (<a href="{{ ref.get_absolute_url }}">{{ ref.id }}</a>)
 <a href="{% url "apis_bibsonomy:referencedelete" ref.id %}?redirect={% url "apis_bibsonomy:referencedetail" reference.id %}">Delete</a>
+{% endwith %}
 </li>
 {% endfor %}
 </ul>

--- a/apis_bibsonomy/views.py
+++ b/apis_bibsonomy/views.py
@@ -2,8 +2,6 @@ from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import DeleteView
 from django.urls import reverse_lazy
-from django.conf import settings
-from django.db.models import Q
 
 from .models import Reference
 
@@ -11,27 +9,9 @@ from .models import Reference
 class ReferenceDetailView(DetailView):
     model = Reference
 
-    def get_similar_objects(self):
-        # we collect a list of other references instances, that point to the
-        # same reference, and add that to the context
-        obj = self.get_object()
-        similarity_fields = getattr(
-            settings,
-            "REFERENCE_SIMILARITY",
-            ["bibs_url"],
-        )
-        similarity = Q()
-        for field in similarity_fields:
-            similarity &= Q(**{field: getattr(obj, field)})
-        return Reference.objects.filter(similarity)
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        similar_references = self.get_similar_objects()
-        context["referenced_objects"] = [
-            (ref, ref.content_type.get_object_for_this_type(id=ref.object_id))
-            for ref in similar_references
-        ]
+        context["similar_references"] = self.get_object().similar_references
         return context
 
 


### PR DESCRIPTION
The `similar_references` logic refers to an instance of a Reference and
should therefore be part of the model and not the view. The same is true
for the lookup of the referenced object. Both those functionalities are
now part of the model. The `similar_references` property of the
Reference now by default exludes self.
The template now displays the object the reference references.
