### PR TITLE
feat: implement bibtex logic in Reference.save()

### DIFF
--- a/apis_bibsonomy/models.py
+++ b/apis_bibsonomy/models.py
@@ -3,9 +3,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.conf import settings
 from django.db.models import Q
+from .utils import BibsonomyEntry, get_bibtex_from_url
+from django.conf import settings
+import requests
 
 import json
-
 
 class Reference(models.Model):
     """Model that holds the reference to a bibsonomy entry"""
@@ -51,3 +53,21 @@ class Reference(models.Model):
         if not with_self:
             return Reference.objects.exclude(pk=self.pk).filter(similarity)
         return Reference.objects.filter(similarity)
+
+
+
+    def save(
+        self, force_insert=False, force_update=False, using=None, update_fields=None
+    ):
+
+        if update_fields is not None and "bibtex" in update_fields:
+            self.bibtex = None
+        if self.bibtex is None and self.bibs_url is not None:
+            self.bibtex = get_bibtex_from_url(self.bibs_url)
+
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )


### PR DESCRIPTION
The logic to fill the bibtex data should be part of the `save()` method
of the Reference model. This way anywhere an instance is saved, the
bibtex data is fetched.
The logic is copied from the api_views.SaveBibsonomyEntry.post() method
and refactored a bit.
