### PR TITLE
feat: implement referenceonlist view

### DIFF
--- a/apis_bibsonomy/templates/apis_bibsonomy/partials/reference_list.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/partials/reference_list.html
@@ -1,0 +1,10 @@
+<ul>
+{% for reference in object_list %}
+<li>
+	<a href="{{ reference.get_absolute_url }}">{{ reference }} ({{ reference.id }})</a>
+</li>
+{% empty %}
+<li>No references yet.</li>
+{% endfor %}
+</ul>
+

--- a/apis_bibsonomy/templates/apis_bibsonomy/reference_list.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/reference_list.html
@@ -5,14 +5,6 @@
 <div class="px-4 py-5 my-5 text-center">
 <h1>References:</h1>
 </div>
-<ul>
-{% for reference in object_list %}
-<li>
-	<a href="{{ reference.get_absolute_url }}">{{ reference }} ({{ reference.id }})</a>
-</li>
-{% empty %}
-<li>No references yet.</li>
-{% endfor %}
-</ul>
+{% include "apis_bibsonomy/partials/reference_list.html" %}
 </div>
 {% endblock content %}

--- a/apis_bibsonomy/urls.py
+++ b/apis_bibsonomy/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('references/', views.ReferenceListView.as_view(), name='referencelist'),
     path('references/<int:pk>', views.ReferenceDetailView.as_view(), name='referencedetail'),
     path('references/<int:pk>/delete', views.ReferenceDeleteView.as_view(), name='referencedelete'),
+    path('referenceson/<int:contenttype>/<int:pk>', views.ReferenceOnListView.as_view(), name="referenceonlist"),
 ]

--- a/apis_bibsonomy/views.py
+++ b/apis_bibsonomy/views.py
@@ -1,7 +1,9 @@
+from django.contrib.contenttypes.models import ContentType
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import DeleteView
 from django.urls import reverse_lazy
+from django.http import Http404
 
 from .models import Reference
 
@@ -27,3 +29,20 @@ class ReferenceDeleteView(DeleteView):
 
 class ReferenceListView(ListView):
     model = Reference
+
+class ReferenceOnListView(ReferenceListView):
+    def get_queryset(self):
+        pk = self.kwargs.get("pk")
+        contenttype = self.kwargs.get("contenttype")
+        try:
+            contenttype = ContentType.objects.get_for_id(contenttype)
+        except ContentType.DoesNotExist:
+            raise Http404
+        return self.model.objects.filter(content_type=contenttype, object_id=pk)
+
+    def get_template_names(self):
+        # return only a partial if the request is ajax or htmx
+        partial = "HX-Request" in self.request.headers or self.request.headers.get('x-requested-with') == 'XMLHttpRequest'
+        if partial:
+            return "apis_bibsonomy/partials/reference_list.html"
+        return super().get_template_names()


### PR DESCRIPTION
This commit introduces a `referenceonlist` view. This view lists all
references on a specific model instance. It reuses the existing
`reference_list.html` template, but splits out the actual list into a
partial. The view by default returns the whole html page, but for
ajax/htmx requests returns only the partial.
