### PR TITLE
fix(views): set htmx to use API delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ APIS_BIBSONOMY_FIELDS = ['name', 'first_name', 'profession']
 Restart your server and you are good to go.
 
 
+### htmx
+
+APIS Bibsonomy uses htmx. The delete buttons for references trigger deletion
+via the API delete route which give an empty response on success. HTMX needs to
+be [configured to swap the content even if the response is empty](https://github.com/bigskysoftware/htmx/issues/199):
+```
+document.body.addEventListener('htmx:beforeSwap', function(event) {
+  if (event.detail.xhr.status === 204) {
+    // Swap content even when the response is empty.
+    event.detail.shouldSwap = true;
+  }
+});
+```
+
+
 ## Usage
 
 *not needed if you are using standard APIS templates*

--- a/apis_bibsonomy/templates/apis_bibsonomy/partials/reference_list.html
+++ b/apis_bibsonomy/templates/apis_bibsonomy/partials/reference_list.html
@@ -6,7 +6,7 @@
   {% if request.user.is_authenticated %}
   <a href="{{ reference.get_absolute_url }}">{{ reference }} ({{ reference.id }})</a>
   <a href="{% url "apis_bibsonomy:referencedelete" reference.id %}?redirect={{ request.path }}"
-     hx-delete="{% url "apis_bibsonomy:referencedelete" reference.id %}"
+     hx-delete="{% url "apis_bibsonomy:reference-detail" reference.id %}"
      hx-confirm="Are your sure you want to delete reference {{ reference }} for {{ reference.referenced_object }}"
      hx-target="closest li"
      hx-swap="outerHTML swap:1s">Delete</a>

--- a/apis_bibsonomy/views.py
+++ b/apis_bibsonomy/views.py
@@ -28,13 +28,6 @@ class ReferenceDeleteView(LoginRequiredMixin, DeleteView):
         )
         return red
 
-    def delete(self, request, *args, **kwargs):
-        resp = super().delete(request, *args, **kwargs)
-        # we set the status code to 200 for HTMX requests, so they don't get redirected
-        if "HX-Request" in request.headers:
-            resp.status_code = 200
-        return resp
-
 
 class ReferenceListView(ListView):
     model = Reference


### PR DESCRIPTION
The API provides an endpoint to delete references. We can use that for
the htmx `hx-delete` argument instead of using the delete view and
configuring it to react on htmx requests.
